### PR TITLE
fix raising exception issue when zero stream access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,4 @@
-\
+# Changelog
+
+## 0.0.1
+  * Initial Commit

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="tap-ms-graph",
       py_modules=["tap_ms_graph"],
       install_requires=[
         "singer-python==6.8.0",
-        "requests==2.33.1",
+        "requests==2.34.2",
         "backoff==2.2.1"
       ],
         extras_require={

--- a/tap_ms_graph/discover.py
+++ b/tap_ms_graph/discover.py
@@ -47,7 +47,13 @@ def _probe_child_access(client, stream_cls, stream_name) -> Set[str]:
             )
             inaccessible.add(child_stream_name)
         except MsGraphBadRequestError as e:
-            if "license" in str(e).lower() or "does not have" in str(e).lower():
+            error_msg = str(e).lower()
+            if any(phrase in error_msg for phrase in (
+                "license",
+                "does not have",
+                "not supported",
+                "application-only",
+            )):
                 LOGGER.warning(
                     "Child stream '%s' is not accessible and will be excluded from the catalog.",
                     child_stream_name,
@@ -71,7 +77,13 @@ def _check_top_level_access(client, stream_name, stream_cls, accessible_top_leve
         )
         return False
     except MsGraphBadRequestError as e:
-        if "license" in str(e).lower() or "does not have" in str(e).lower():
+        error_msg = str(e).lower()
+        if any(phrase in error_msg for phrase in (
+            "license",
+            "does not have",
+            "not supported",
+            "application-only",
+        )):
             LOGGER.warning(
                 "Stream '%s' is not accessible and will be excluded from the catalog.",
                 stream_name,
@@ -100,7 +112,7 @@ def _is_child_stream_accessible(stream_name, stream_cls, accessible_top_level, i
     return True
 
 
-def discover(client=None) -> Catalog:
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
     """
@@ -120,19 +132,18 @@ def discover(client=None) -> Catalog:
     for stream_name, schema_dict in sorted_streams:
         stream_cls = STREAMS.get(stream_name)
 
-        if client:
-            if stream_cls is None:
-                # Stream exists in schemas but has no registered class; skip when
-                # a client is present since we cannot verify access.
+        if stream_cls is None:
+            # Stream exists in schemas but has no registered class; skip since
+            # we cannot verify access.
+            continue
+        if not stream_cls.parent:
+            # ---- Top-level stream: check access, then probe children ----
+            if not _check_top_level_access(client, stream_name, stream_cls, accessible_top_level, inaccessible_child_streams):
                 continue
-            if not stream_cls.parent:
-                # ---- Top-level stream: check access, then probe children ----
-                if not _check_top_level_access(client, stream_name, stream_cls, accessible_top_level, inaccessible_child_streams):
-                    continue
-            else:
-                # ---- Child stream: skip if parent or self is inaccessible ----
-                if not _is_child_stream_accessible(stream_name, stream_cls, accessible_top_level, inaccessible_child_streams):
-                    continue
+        else:
+            # ---- Child stream: skip if parent or self is inaccessible ----
+            if not _is_child_stream_accessible(stream_name, stream_cls, accessible_top_level, inaccessible_child_streams):
+                continue
 
         try:
             schema = Schema.from_dict(schema_dict)
@@ -151,5 +162,16 @@ def discover(client=None) -> Catalog:
         except Exception as err:
             LOGGER.error(f"Error processing stream '{stream_name}'")
             raise err
+
+    if not catalog.streams:
+        LOGGER.error(
+            "Discovery returned an empty catalog: no streams are accessible with the "
+            "provided credentials. Verify that the service principal / user has the "
+            "required Microsoft Graph API permissions."
+        )
+        raise MsGraphForbiddenError(
+            "No streams are accessible. Check that the configured credentials have "
+            "the required Microsoft Graph API permissions."
+        )
 
     return catalog

--- a/tap_ms_graph/streams/abstracts.py
+++ b/tap_ms_graph/streams/abstracts.py
@@ -10,6 +10,7 @@ from singer import (
     write_schema,
     metadata
 )
+from tap_ms_graph.exceptions import MsGraphNotFoundError
 
 LOGGER = get_logger()
 
@@ -137,9 +138,17 @@ class BaseStream(ABC):
         next_page = 1
         params = self.params
         while next_page:
-            response = self.client.get(
-                self.url_endpoint, params, self.headers, self.path
-            )
+            try:
+                response = self.client.get(
+                    self.url_endpoint, params, self.headers, self.path
+                )
+            except MsGraphNotFoundError:
+                LOGGER.warning(
+                    "Resource not found for stream '%s' (endpoint: %s); skipping.",
+                    self.tap_stream_id,
+                    self.url_endpoint,
+                )
+                return
             raw_records = response.get(self.data_key, [])
             next_page = response.get(self.next_page_key)
             if next_page:

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -51,19 +51,22 @@ def schemas_and_metadata():
 
 
 # ---------------------------------------------------------------------------
-# Tests: discover() without a client (no permission check)
+# Tests: discover() — schema structure (permission checks skipped via mock)
 # ---------------------------------------------------------------------------
 
-class TestDiscoverWithoutClient:
+class TestDiscoverSchemaStructure:
     def test_returns_all_streams(self, schemas_and_metadata):
         schemas, field_metadata = schemas_and_metadata
+        mock_client = MagicMock()
         mock_streams = _make_streams(
             {"users": "", "groups": "", "group_member": "groups"}
         )
+        for cls in mock_streams.values():
+            cls.check_access.return_value = None
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(schemas, field_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            catalog = discover(client=None)
+            catalog = discover(client=mock_client)
 
         stream_names = {e.stream for e in catalog.streams}
         assert stream_names == {"users", "groups", "group_member"}
@@ -71,33 +74,39 @@ class TestDiscoverWithoutClient:
     def test_returns_catalog_instance(self, schemas_and_metadata):
         from singer.catalog import Catalog
         schemas, field_metadata = schemas_and_metadata
+        mock_client = MagicMock()
         mock_streams = _make_streams({"users": ""})
+        mock_streams["users"].check_access.return_value = None
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(schemas, field_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            catalog = discover(client=None)
+            catalog = discover(client=mock_client)
 
         assert isinstance(catalog, Catalog)
 
     def test_catalog_entries_have_key_properties(self, schemas_and_metadata):
         schemas, field_metadata = schemas_and_metadata
+        mock_client = MagicMock()
         mock_streams = _make_streams({"users": ""})
+        mock_streams["users"].check_access.return_value = None
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(schemas, field_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            catalog = discover(client=None)
+            catalog = discover(client=mock_client)
 
         assert catalog.streams[0].key_properties == ["id"]
 
-    def test_no_check_access_called_without_client(self, schemas_and_metadata):
+    def test_check_access_called_for_top_level_streams(self, schemas_and_metadata):
         schemas, field_metadata = schemas_and_metadata
+        mock_client = MagicMock()
         mock_streams = _make_streams({"users": ""})
+        mock_streams["users"].check_access.return_value = None
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(schemas, field_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            discover(client=None)
+            discover(client=mock_client)
 
-        mock_streams["users"].check_access.assert_not_called()
+        mock_streams["users"].check_access.assert_called_once_with(mock_client)
 
 
 # ---------------------------------------------------------------------------
@@ -145,10 +154,8 @@ class TestDiscoverWithClient:
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(schemas, field_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            catalog = discover(client=mock_client)
-
-        # All streams inaccessible → catalog is empty (no raise)
-        assert catalog.streams == []
+            with pytest.raises(MsGraphForbiddenError, match="No streams are accessible"):
+                discover(client=mock_client)
 
     def test_child_excluded_when_parent_inaccessible(self, schemas_and_metadata):
         schemas, field_metadata = schemas_and_metadata
@@ -215,10 +222,9 @@ class TestDiscoverWithClient:
 
         with patch("tap_ms_graph.discover.get_schemas", return_value=(extra_schemas, extra_metadata)), \
              patch("tap_ms_graph.discover.STREAMS", mock_streams):
-            # All top-level streams forbidden → empty catalog
-            catalog = discover(client=mock_client)
-
-        assert catalog.streams == []
+            # All top-level streams forbidden → raises MsGraphForbiddenError
+            with pytest.raises(MsGraphForbiddenError, match="No streams are accessible"):
+                discover(client=mock_client)
 
     def test_catalog_entries_have_tap_stream_id(self, schemas_and_metadata):
         schemas, field_metadata = schemas_and_metadata

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -13,6 +13,7 @@ from tap_ms_graph.exceptions import (
     MsGraphBadRequestError,
     MsGraphBackoffError,
     MsGraphInternalServerError,
+    MsGraphNotFoundError,
 )
 
 
@@ -231,6 +232,21 @@ class TestGetRecords:
 
         assert len(records) == 3
         assert client.get.call_count == 3
+
+    def test_not_found_404_yields_nothing_and_no_exception(self):
+        """A 404 MsGraphNotFoundError means the resource does not exist for
+        this parent (e.g. a user with no OneDrive).  get_records() must return
+        an empty iterator rather than propagating the exception."""
+        client = make_client()
+        entry = make_catalog_entry()
+        client.get.side_effect = MsGraphNotFoundError("HTTP-error-code: 404, Error: User's mysite not found.")
+
+        stream = Users(client, entry)
+        stream.update_params()
+        records = list(stream.get_records())
+
+        assert records == []
+        client.get.assert_called_once()  # no retry after 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description of change
This PR addresses two runtime failure modes in tap-ms-graph: discovery crashing for tenants where certain Microsoft Graph APIs are unavailable in application-only context, and sync crashing when a child-stream resource does not exist for a specific parent record.

# Manual QA steps
- [x]  Discovery: running
- [x]  Sync: running
- [x]  Unit Tests: running
- [x]  Integration test
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
